### PR TITLE
feat: use total value for distribution instead of APY

### DIFF
--- a/.github/workflows/codecommit.yml
+++ b/.github/workflows/codecommit.yml
@@ -1,0 +1,30 @@
+name: sync to codecommit
+
+on:
+  push:
+    tags:
+      - '*'
+    branches:
+      - '*'
+
+jobs:
+  sync:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@v1
+        with:
+          aws-access-key-id: ${{ secrets.CC_ACCESS_KEY }}
+          aws-secret-access-key: ${{ secrets.CC_SECRET_KEY }}
+          aws-region: us-east-1
+
+      - name: Sync up to CodeCommit
+        uses: terra-money/sync-up-to-codecommit-action@v1
+        with:
+          repository_name: ${{ github.event.repository.name }}
+          aws_region: us-east-1

--- a/README.md
+++ b/README.md
@@ -1,13 +1,13 @@
 # Benchmark 
-The smart contract has been deployed to [pisco-1 testnet](https://finder.terra.money/testnet/address/terra1uysfaxm4sjd7j35cw484w3ky3v6fkpffgrzv63mp6mj64xdamp2stf6hmt) and it has been benchmarked with the following data:
+The smart contract has been deployed to [pisco-1 testnet](https://terrasco.pe/testnet/address/terra1uysfaxm4sjd7j35cw484w3ky3v6fkpffgrzv63mp6mj64xdamp2stf6hmt) and it has been benchmarked with the following data:
 
 | Size   | Chains | Alliances | Data Size (kB) | Tx Cost (Luna) | Gas Used  |
 |--------|--------|-----------|----------------|----------------|-----------|
-| [XSmall](https://finder.terra.money/testnet/tx/4EFB6A2CA53C54449B303CF3C91593E161E12195E0C302E9504ECF67EBF00078)  | 8     | 16        | 5,5             | 0.406522       | 354,576   |
-| [Small](https://finder.terra.money/testnet/tx/D04758D0E6B1DF1B910ACB0473A3C232273A12D06A670CA0DB4AF53CA9981ECB)  | 16     | 32        | 11             | 0.667318       | 574,760   |
-| [Medium](https://finder.terra.money/testnet/tx/7BFCFDB5D378C58BFCF117660C57DC7C909D6EB45C316F86FFD4FD255EA8C5C7) | 32     | 64        | 21,9           | 1.188321       | 1,008,969 |
-| [Large](https://finder.terra.money/testnet/tx/3DF693DAC85B3D0EAFFFCA580031DD81D106F01CE582DC7EAB5D3C14F41F833E)  | 64     | 124       | 43,7           | 2.230764       | 1,877,682 |
-| [XLarge](https://finder.terra.money/testnet/tx/9BA0C5C18D6BC484112A7C15F5E1ECCBB4D80C1CF117895E08A375F182407325)  | 124     | 248       | 87,4           | 4.319313       | 3,615,282 |
+| [XSmall](https://terrasco.pe/testnet/tx/4EFB6A2CA53C54449B303CF3C91593E161E12195E0C302E9504ECF67EBF00078)  | 8     | 16        | 5,5             | 0.406522       | 354,576   |
+| [Small](https://terrasco.pe/testnet/tx/D04758D0E6B1DF1B910ACB0473A3C232273A12D06A670CA0DB4AF53CA9981ECB)  | 16     | 32        | 11             | 0.667318       | 574,760   |
+| [Medium](https://terrasco.pe/testnet/tx/7BFCFDB5D378C58BFCF117660C57DC7C909D6EB45C316F86FFD4FD255EA8C5C7) | 32     | 64        | 21,9           | 1.188321       | 1,008,969 |
+| [Large](https://terrasco.pe/testnet/tx/3DF693DAC85B3D0EAFFFCA580031DD81D106F01CE582DC7EAB5D3C14F41F833E)  | 64     | 124       | 43,7           | 2.230764       | 1,877,682 |
+| [XLarge](https://terrasco.pe/testnet/tx/9BA0C5C18D6BC484112A7C15F5E1ECCBB4D80C1CF117895E08A375F182407325)  | 124     | 248       | 87,4           | 4.319313       | 3,615,282 |
 
 Take in consideration that the XLarge dataset almost reach the limit of data we can submit on chain since the maximum gas for queries is 3 000 000 and the size of the data is quiet large. 
 
@@ -15,10 +15,10 @@ Take in consideration that the XLarge dataset almost reach the limit of data we 
 
 |        | Network             | CodeID | Contract Address                                                 |
 |--------|---------------------|--------|------------------------------------------------------------------|
-| Oracle | testnet (pisco-1)   | 9900   | [terra1w8ta7vhpzwe0y99tvvtp7k0k8uex2jq8jts8k2hsyg009ya06qts5fwftt](https://finder.terra.money/testnet/address/terra1w8ta7vhpzwe0y99tvvtp7k0k8uex2jq8jts8k2hsyg009ya06qts5fwftt) |
-| Hub    | testnet (pisco-1)   | 10047   | [terra1eaxcahzxp0x8wqejqjlqaey53tp06l728qad6z395lyzgl026qkq20xj43](https://finder.terra.money/testnet/address/terra1eaxcahzxp0x8wqejqjlqaey53tp06l728qad6z395lyzgl026qkq20xj43) |
-| Oracle | mainnet (phoenix-1) | 1734   | [terra1mdpvgjc8jmv60a4x68nggsh9w8uyv69sqls04a76m9med5hsqmwsse8sxa](https://finder.terra.money/mainnet/address/terra1mdpvgjc8jmv60a4x68nggsh9w8uyv69sqls04a76m9med5hsqmwsse8sxa)                                                                 |
-| Hub    | mainnet (phoenix-1) | 1778   | [terra1jwyzzsaag4t0evnuukc35ysyrx9arzdde2kg9cld28alhjurtthq0prs2s](https://finder.terra.money/mainnet/address/terra1jwyzzsaag4t0evnuukc35ysyrx9arzdde2kg9cld28alhjurtthq0prs2s)                                                                 |
+| Oracle | testnet (pisco-1)   | 10056   | [terra1w8ta7vhpzwe0y99tvvtp7k0k8uex2jq8jts8k2hsyg009ya06qts5fwftt](https://terrasco.pe/testnet/address/terra1w8ta7vhpzwe0y99tvvtp7k0k8uex2jq8jts8k2hsyg009ya06qts5fwftt) |
+| Hub    | testnet (pisco-1)   | 10047   | [terra1eaxcahzxp0x8wqejqjlqaey53tp06l728qad6z395lyzgl026qkq20xj43](https://terrasco.pe/testnet/address/terra1eaxcahzxp0x8wqejqjlqaey53tp06l728qad6z395lyzgl026qkq20xj43) |
+| Oracle | mainnet (phoenix-1) | 1782   | [terra1mdpvgjc8jmv60a4x68nggsh9w8uyv69sqls04a76m9med5hsqmwsse8sxa](https://chainsco.pe/terra2/address/terra1mdpvgjc8jmv60a4x68nggsh9w8uyv69sqls04a76m9med5hsqmwsse8sxa)                                                                 |
+| Hub    | mainnet (phoenix-1) | 1778   | [terra1jwyzzsaag4t0evnuukc35ysyrx9arzdde2kg9cld28alhjurtthq0prs2s](https://chainsco.pe/terra2/address/terra1jwyzzsaag4t0evnuukc35ysyrx9arzdde2kg9cld28alhjurtthq0prs2s)                                                                 |
 
 # Development
 

--- a/contracts/alliance-oracle/src/tests/mod.rs
+++ b/contracts/alliance-oracle/src/tests/mod.rs
@@ -725,11 +725,13 @@ fn test_emissions_distribution_6() {
             "migaloo-1".to_string(),
             vec![
                 AssetStaked {
-                denom: "ibc/B3F639855EE7478750CC8F82072307ED6E131A8EFF20345E1D136B50C4E5EC36".to_string(),
-                amount: Uint128::new(9486165779396),
-            },
+                    denom: "ibc/B3F639855EE7478750CC8F82072307ED6E131A8EFF20345E1D136B50C4E5EC36"
+                        .to_string(),
+                    amount: Uint128::new(9486165779396),
+                },
                 AssetStaked {
-                    denom: "ibc/517E13F14A1245D4DE8CF467ADD4DA0058974CDCC880FA6AE536DBCA1D16D84E".to_string(),
+                    denom: "ibc/517E13F14A1245D4DE8CF467ADD4DA0058974CDCC880FA6AE536DBCA1D16D84E"
+                        .to_string(),
                     amount: Uint128::new(2371896858539),
                 },
             ],
@@ -737,7 +739,8 @@ fn test_emissions_distribution_6() {
         (
             "carbon-1".to_string(),
             vec![AssetStaked {
-                denom: "ibc/0E90026619DD296AD4EF9546396F292B465BAB6B5BE00ABD6162AA1CE8E68098".to_string(),
+                denom: "ibc/0E90026619DD296AD4EF9546396F292B465BAB6B5BE00ABD6162AA1CE8E68098"
+                    .to_string(),
                 amount: Uint128::new(1082956075803),
             }],
         ),
@@ -749,15 +752,18 @@ fn test_emissions_distribution_6() {
         res_parsed,
         vec![
             EmissionsDistribution {
-                denom: "ibc/B3F639855EE7478750CC8F82072307ED6E131A8EFF20345E1D136B50C4E5EC36".to_string(),
+                denom: "ibc/B3F639855EE7478750CC8F82072307ED6E131A8EFF20345E1D136B50C4E5EC36"
+                    .to_string(),
                 distribution: SignedDecimal::from_str("11564.766237041663021737").unwrap(),
             },
             EmissionsDistribution {
-                denom: "ibc/517E13F14A1245D4DE8CF467ADD4DA0058974CDCC880FA6AE536DBCA1D16D84E".to_string(),
+                denom: "ibc/517E13F14A1245D4DE8CF467ADD4DA0058974CDCC880FA6AE536DBCA1D16D84E"
+                    .to_string(),
                 distribution: SignedDecimal::from_str("2865.208859003817351703").unwrap(),
             },
             EmissionsDistribution {
-                denom: "ibc/0E90026619DD296AD4EF9546396F292B465BAB6B5BE00ABD6162AA1CE8E68098".to_string(),
+                denom: "ibc/0E90026619DD296AD4EF9546396F292B465BAB6B5BE00ABD6162AA1CE8E68098"
+                    .to_string(),
                 distribution: SignedDecimal::from_str("10865.475734855229839771").unwrap(),
             }
         ]

--- a/contracts/alliance-oracle/src/tests/mod.rs
+++ b/contracts/alliance-oracle/src/tests/mod.rs
@@ -189,7 +189,7 @@ fn test_emissions_distribution() {
         res_parsed,
         vec![EmissionsDistribution {
             denom: "ibc/randomd_denom".to_string(),
-            distribution: SignedDecimal::from_str("0.176008427567596192").unwrap(),
+            distribution: SignedDecimal::from_str("2359.77843").unwrap(),
         }]
     )
 }
@@ -284,11 +284,11 @@ fn test_emissions_distribution_2() {
         vec![
             EmissionsDistribution {
                 denom: "ibc/randomd_denom".to_string(),
-                distribution: SignedDecimal::from_str("0.176008427567596192").unwrap(),
+                distribution: SignedDecimal::from_str("2359.77843").unwrap(),
             },
             EmissionsDistribution {
                 denom: "ibc/randomd_denom2".to_string(),
-                distribution: SignedDecimal::from_str("0.180182056404448192").unwrap(),
+                distribution: SignedDecimal::from_str("12807.66973481792").unwrap(),
             }
         ]
     )
@@ -384,11 +384,11 @@ fn test_emissions_distribution_3() {
         vec![
             EmissionsDistribution {
                 denom: "ibc/randomd_denom".to_string(),
-                distribution: SignedDecimal::from_str("0.176008427567596192").unwrap(),
+                distribution: SignedDecimal::from_str("2359.77843").unwrap(),
             },
             EmissionsDistribution {
                 denom: "ibc/randomd_denom2".to_string(),
-                distribution: SignedDecimal::from_str("0.180182056404448192").unwrap(),
+                distribution: SignedDecimal::from_str("12807.66973481792").unwrap(),
             }
         ]
     )
@@ -501,15 +501,15 @@ fn test_emissions_distribution_4() {
         vec![
             EmissionsDistribution {
                 denom: "ibc/randomd_denom".to_string(),
-                distribution: SignedDecimal::from_str("0.176008427567596192").unwrap(),
+                distribution: SignedDecimal::from_str("2359.77843").unwrap(),
             },
             EmissionsDistribution {
                 denom: "ibc/randomd_denom2".to_string(),
-                distribution: SignedDecimal::from_str("0.120121370936298794").unwrap(),
+                distribution: SignedDecimal::from_str("17076.892979757226666666").unwrap(),
             },
             EmissionsDistribution {
                 denom: "ibc/randomd_denom3".to_string(),
-                distribution: SignedDecimal::from_str("0.060060685468149397").unwrap(),
+                distribution: SignedDecimal::from_str("8538.446489878613333333").unwrap(),
             }
         ]
     )
@@ -616,11 +616,149 @@ fn test_emissions_distribution_5() {
         vec![
             EmissionsDistribution {
                 denom: "ibc/randomd_denom".to_string(),
-                distribution: SignedDecimal::from_str("0.176008427567596192").unwrap(),
+                distribution: SignedDecimal::from_str("2359.77843").unwrap(),
             },
             EmissionsDistribution {
                 denom: "ibc/randomd_denom2".to_string(),
-                distribution: SignedDecimal::from_str("0.243576075205930923").unwrap(),
+                distribution: SignedDecimal::from_str("25970.74860388584").unwrap(),
+            }
+        ]
+    )
+}
+
+#[test]
+fn test_emissions_distribution_6() {
+    let mut deps = test_utils::setup_contract();
+    let env = mock_env();
+    CHAINS_INFO
+        .save(
+            deps.as_mut().storage,
+            &vec![
+                ChainInfo {
+                    chain_id: "migaloo-1".to_string(),
+                    update_timestamp: env.block.time,
+                    native_token: NativeToken {
+                        denom: "uwhale".to_string(),
+                        token_price: Decimal::from_str("0.013524549476922628").unwrap(),
+                        annual_provisions: Decimal::from_str("23736452.03675").unwrap(),
+                    },
+                    luna_alliances: vec![
+                        LunaAlliance {
+                        ibc_denom: String::from(
+                            "ibc/05238E98A143496C8AF2B6067BABC84503909ECE9E45FBCBAC2CBA5C889FD82A",
+                        ),
+                        normalized_reward_weight: Decimal::from_str("0.02380952380952381").unwrap(),
+                        annual_take_rate: Decimal::from_str("0.009999998624824108").unwrap(),
+                        total_lsd_staked: Decimal::from_str("88823.181957").unwrap(),
+                        rebase_factor: Decimal::from_str("1.218914581562127104").unwrap(),
+                    },
+                        LunaAlliance {
+                            ibc_denom: String::from(
+                                "ibc/40C29143BF4153B365089E40E437B7AA819672646C45BB0A5F1E10915A0B6708",
+                            ),
+                            normalized_reward_weight: Decimal::from_str("0.02380952380952381").unwrap(),
+                            annual_take_rate: Decimal::from_str("0.009999998624824108").unwrap(),
+                            total_lsd_staked: Decimal::from_str("87428.265672").unwrap(),
+                            rebase_factor: Decimal::from_str("1.090788276739635233").unwrap(),
+                        },
+                    ],
+                    chain_alliances_on_phoenix: vec![
+                        BaseAlliance {
+                        ibc_denom: String::from("ibc/B3F639855EE7478750CC8F82072307ED6E131A8EFF20345E1D136B50C4E5EC36"),
+                        rebase_factor: Decimal::from_str("1.047512402009788029").unwrap(),
+                    },
+                        BaseAlliance {
+                            ibc_denom: String::from("ibc/517E13F14A1245D4DE8CF467ADD4DA0058974CDCC880FA6AE536DBCA1D16D84E"),
+                            rebase_factor: Decimal::from_str("1.037943014367716314").unwrap(),
+                        },
+                    ],
+                },
+                ChainInfo {
+                    chain_id: "carbon-1".to_string(),
+                    update_timestamp: env.block.time,
+                    native_token: NativeToken {
+                        denom: "swth".to_string(),
+                        token_price: Decimal::from_str("0.00412912495495493").unwrap(),
+                        annual_provisions: Decimal::from_str("135254591.043743106597827288").unwrap(),
+                    },
+                    luna_alliances: vec![
+                        LunaAlliance {
+                            ibc_denom: String::from(
+                                "ibc/62A3870B9804FC3A92EAAA1F0F3F07E089DBF76CC521466CA33F5AAA8AD42290",
+                            ),
+                            normalized_reward_weight: Decimal::from_str("0.009803921568627451").unwrap(),
+                            annual_take_rate: Decimal::from_str("0.003000000004214211").unwrap(),
+                            total_lsd_staked: Decimal::from_str("30172.229513").unwrap(),
+                            rebase_factor: Decimal::from_str("1.218914581562127104").unwrap(),
+                        },
+                        LunaAlliance {
+                            ibc_denom: String::from(
+                                "ibc/FBEE20115530F474F8BBE1460DA85437C3FBBFAF4A5DEBD71CA6B9C40559A161",
+                            ),
+                            normalized_reward_weight: Decimal::from_str("0.009803921568627451").unwrap(),
+                            annual_take_rate: Decimal::from_str("0.003000000004214211").unwrap(),
+                            total_lsd_staked: Decimal::from_str("28119.651782").unwrap(),
+                            rebase_factor: Decimal::from_str("1.091394368297982073").unwrap(),
+                        }
+                    ],
+                    chain_alliances_on_phoenix: vec![BaseAlliance {
+                        ibc_denom: String::from("ibc/0E90026619DD296AD4EF9546396F292B465BAB6B5BE00ABD6162AA1CE8E68098"),
+                        rebase_factor: Decimal::from_str("1.011507").unwrap(),
+                    }],
+                },
+            ],
+        )
+        .unwrap();
+
+    LUNA_INFO
+        .save(
+            deps.as_mut().storage,
+            &LunaInfo {
+                luna_price: Decimal::from_str("0.4208152366587659").unwrap(),
+                update_timestamp: env.block.time,
+            },
+        )
+        .unwrap();
+
+    let msg = QueryMsg::QueryEmissionsDistributions(HashMap::from([
+        (
+            "migaloo-1".to_string(),
+            vec![
+                AssetStaked {
+                denom: "ibc/B3F639855EE7478750CC8F82072307ED6E131A8EFF20345E1D136B50C4E5EC36".to_string(),
+                amount: Uint128::new(9486165779396),
+            },
+                AssetStaked {
+                    denom: "ibc/517E13F14A1245D4DE8CF467ADD4DA0058974CDCC880FA6AE536DBCA1D16D84E".to_string(),
+                    amount: Uint128::new(2371896858539),
+                },
+            ],
+        ),
+        (
+            "carbon-1".to_string(),
+            vec![AssetStaked {
+                denom: "ibc/0E90026619DD296AD4EF9546396F292B465BAB6B5BE00ABD6162AA1CE8E68098".to_string(),
+                amount: Uint128::new(1082956075803),
+            }],
+        ),
+    ]));
+
+    let res = query(deps.as_ref(), mock_env(), msg).unwrap();
+    let res_parsed: Vec<EmissionsDistribution> = from_binary(&res).unwrap();
+    assert_eq!(
+        res_parsed,
+        vec![
+            EmissionsDistribution {
+                denom: "ibc/B3F639855EE7478750CC8F82072307ED6E131A8EFF20345E1D136B50C4E5EC36".to_string(),
+                distribution: SignedDecimal::from_str("11564.766237041663021737").unwrap(),
+            },
+            EmissionsDistribution {
+                denom: "ibc/517E13F14A1245D4DE8CF467ADD4DA0058974CDCC880FA6AE536DBCA1D16D84E".to_string(),
+                distribution: SignedDecimal::from_str("2865.208859003817351703").unwrap(),
+            },
+            EmissionsDistribution {
+                denom: "ibc/0E90026619DD296AD4EF9546396F292B465BAB6B5BE00ABD6162AA1CE8E68098".to_string(),
+                distribution: SignedDecimal::from_str("10865.475734855229839771").unwrap(),
             }
         ]
     )


### PR DESCRIPTION
Use total value instead of APY (as a % over LUNA staked) to distribute alliance rewards. Using yield for distribution unfairly punishes chains who attracted LUNA stakers since more stakers reduces the yield. Instead, rewards should be distributed to total value (in USD) of emissions given to Terra as an ecosystem.